### PR TITLE
Fix comment translation

### DIFF
--- a/src/main/java/net/flazesmp/flazesmpitems/config/ConfigManager.java
+++ b/src/main/java/net/flazesmp/flazesmpitems/config/ConfigManager.java
@@ -356,7 +356,7 @@ public class ConfigManager {
         if (!Files.exists(tooltipConfigFile)) {
             LOGGER.info("Creating tooltip config file: {}", tooltipConfigFile);
             try {
-                // Modification importante ici: structure correcte du fichier TOML
+                // Important: ensure the generated TOML file has the correct structure
                 String tooltipConfig = 
                     "#ItemTooltipEnhancer Tooltip Formatting Configuration\n" +
                     "[general]\n" +


### PR DESCRIPTION
## Summary
- update the tooltip config generation comment in `ConfigManager`

## Testing
- `./gradlew build -x test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6841471da9cc83329de868a30e5123b8